### PR TITLE
Clone message before sending out of the event-in node.

### DIFF
--- a/nodes/event-in.js
+++ b/nodes/event-in.js
@@ -66,7 +66,7 @@ function nodeInstance(config) {
 
     // Event handler
     const sender = (msg) => {
-        this.send(msg)
+        this.send(RED.util.cloneMessage(msg))
     }
 
     // Create new listener for the given topic, record it so that it can be removed on close


### PR DESCRIPTION
Make the message local once it has come out of the event-in node. When using multiple event-in nodes with the same topic this prevents changes made to a message for all event-in nodes.